### PR TITLE
not working, need help: update verified icons on home page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,8 +14,19 @@
       "js": [
         "scripts/content.js"
       ],
+      "exclude_globs": [
+        "*://twitter.com/home"
+      ],
       "matches": [
         "https://twitter.com/*"
+      ]
+    },
+    {
+      "js": [
+        "scripts/home.js"
+      ],
+      "matches": [
+        "https://twitter.com/home"
       ]
     }
   ]

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -1,0 +1,23 @@
+function updateVerfiedIcons(tweet) {
+	const parent = tweet.parentElement;
+	const reactPropsKey = Object.keys(parent).filter((key) =>
+		key.startsWith('__reactProps')
+	)[0];
+	if (reactPropsKey) {
+		const { isBlueVerified, isVerified } =
+			parent[reactPropsKey].children.props.children[0][0].props;
+		if (!isVerified && isBlueVerified) {
+			tweet.style.rotate = `0.5turn`;
+			tweet.style.fill = `#ee8383`;
+		}
+	}
+}
+
+function getAllVerfiedAccounts() {
+	const tweets = document.querySelectorAll(`[aria-label*="Verified account"]`);
+	tweets.forEach((tweet) => {
+		updateVerfiedIcons(tweet);
+	});
+}
+
+setInterval(getAllVerfiedAccounts, 500);


### PR DESCRIPTION
Hey folks 👋,

I saw the video and I was wondering if we could use the React internal state to know if the user is blue-verified. 
![image](https://user-images.githubusercontent.com/10562610/201205431-1311f4fe-ef46-456b-9347-51275cc88f27.png)

Looks like it works locally (if you copy and paste `home.js` into your chrome dev tools it works) but looks like if it comes from the extension it doesn't... My [guess](https://stackoverflow.com/a/73065392/3725320) is it's because the extension "context" is different, even tho I'm not sure... maybe someone smarter can figure it out and I can learn from it :)

P.S: I also added an `exclude_globs` for not running the profile script in `/home` page